### PR TITLE
reusable dropdown

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -408,6 +408,8 @@ function App() {
       <SizeDropdown
         userSettings={userSettings}
         setUserSettings={setUserSettings}
+        settingKey="boardSize"
+        settingOptions={["Small", "Medium", "Large"]}
       />
 
       <RefreshButton
@@ -431,6 +433,10 @@ export default App;
 //
 // COMING UP NEXT
 //
+// Reusable DropDown
+// Add Multiplayer option to UserSettings
+// Start passing Game object that includes board, rather than smaller object
+// Enable user to enter a 
 // Fix the Influence algorithm so that it's rotationally balanced (assessments need to be made off older version of influence board)
 // Replace the boardsizenumber with boardLengthDict[userSettings.boardSize]
 // Count captured pieces somewhere

--- a/src/client/DropDown.tsx
+++ b/src/client/DropDown.tsx
@@ -1,62 +1,55 @@
 import { useState } from "react";
 import { UserSettings } from "./App";
 
-export const SizeDropdown = ({ userSettings, setUserSettings }: { userSettings: UserSettings, setUserSettings: Function}) => {
+export const SizeDropdown = ({ userSettings, setUserSettings, settingKey, settingOptions }: { userSettings: UserSettings, setUserSettings: Function, settingKey: string, settingOptions: string[]}) => {
     const [isOpen, setOpen] = useState(false)
   
     const handleDropDown = () => {
       setOpen(!isOpen)
-      console.log("click registered")
     }
   
-    const handleSelectSmall = (size: string) => {
+    const handleSelect = (size: string) => {
       setUserSettings( {...userSettings, boardSize: size })
-      console.log("Small clicked")
-      console.log("New userSettings", userSettings)
     }
 
-    const bulletClassName = "w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-700 dark:focus:ring-offset-gray-700 focus:ring-2 dark:bg-gray-600 dark:border-gray-500"
+    const humanTextPrep = settingKey.replace(/([A-Z])/g, " $1");
+    const humanText = humanTextPrep.charAt(0).toUpperCase() + humanTextPrep.slice(1).toLowerCase();
+
+    const buttonClass = "text-white bg-green-600 hover:bg-green-400 focus:ring-4 focus:outline-none focus:ring-green-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center inline-flex items-center dark:bg-green-600 dark:hover:bg-green-700 dark:focus:ring-green-800"
+    const dropdownClass = `z-10 w-48 bg-white divide-y divide-gray-100 rounded-lg shadow dark:bg-gray-700 dark:divide-gray-600 
+          ${
+            isOpen ? "block" : "hidden"
+          }
+          `
+    const optionClass = "w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-700 dark:focus:ring-offset-gray-700 focus:ring-2 dark:bg-gray-600 dark:border-gray-500"
+    const optionTextClass = "ms-2 text-sm font-medium text-gray-900 dark:text-gray-300"
 
     return (
       <>
-  
-  <button id="dropdown" onClick={() => handleDropDown()} data-dropdown-toggle="dropdownDefaultRadio" className={`text-white bg-green-600 hover:bg-green-400 focus:ring-4 focus:outline-none focus:ring-green-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center inline-flex items-center dark:bg-green-600 dark:hover:bg-green-700 dark:focus:ring-green-800`} type="button">
-    Board size
-    <svg className="w-2.5 h-2.5 ms-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 10 6">
-  <path stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="m1 1 4 4 4-4"/>
-  </svg>
-  </button>
-  
-  <div id="dropdown" className={`z-10 w-48 bg-white divide-y divide-gray-100 rounded-lg shadow dark:bg-gray-700 dark:divide-gray-600 
-    ${
-      isOpen ? "block" : "hidden"
-    }
-    `}>
-      <ul className="p-3 space-y-3 text-sm text-gray-700 dark:text-gray-200" aria-labelledby="dropdownRadioButton">
-        <li>
-          <div className="flex items-center">
-              <input checked={userSettings.boardSize === "Small"} onChange={() => handleSelectSmall("Small")} id="default-radio-1" type="radio" value="" name="default-radio" className={bulletClassName} />
-              <label htmlFor="default-radio-1" className="ms-2 text-sm font-medium text-gray-900 dark:text-gray-300">Small</label>
-          </div>
-        </li>
-        <li>
-          <div className="flex items-center">
-              <input checked={userSettings.boardSize === "Medium"} onChange={() => handleSelectSmall("Medium")} id="default-radio-2" type="radio" value="" name="default-radio" className={bulletClassName} />
-
-              <label htmlFor="default-radio-2" className="ms-2 text-sm font-medium text-gray-900 dark:text-gray-300">Medium</label>
-          </div>
-        </li>
-        <li>
-          <div className="flex items-center">
-              <input checked={userSettings.boardSize === "Large"} onChange={() => handleSelectSmall("Large")} id="default-radio-3" type="radio" value="" name="default-radio" className={bulletClassName} />
-              <label htmlFor="default-radio-3" className="ms-2 text-sm font-medium text-gray-900 dark:text-gray-300">Large</label>
-          </div>
-        </li>
-      </ul>
-  </div>
-  
-  
-  
-  </>
+        <button id="dropdown" onClick={() => handleDropDown()} data-dropdown-toggle="dropdownDefaultRadio" className={buttonClass} type="button">
+          {humanText}
+          <svg className="w-2.5 h-2.5 ms-3" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 10 6">
+          <path stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="m1 1 4 4 4-4"/>
+        </svg>
+        </button>
+        
+        <div id="dropdown" className={dropdownClass}>
+          <ul className="p-3 space-y-3 text-sm text-gray-700 dark:text-gray-200" aria-labelledby="dropdownRadioButton">
+            {settingOptions.map((optionName, optionIndex)=>{
+              return(
+                <li key={optionIndex}>
+                  <div className="flex items-center">
+                      <input checked={eval("userSettings."+settingKey) === optionName} onChange={() => handleSelect(optionName)} id="default-radio-1" type="radio" value="" name="default-radio" className={optionClass} />
+                      <label htmlFor="default-radio-1" className={optionTextClass}>{optionName}</label>
+                  </div>
+                </li>
+              )
+            })}
+          </ul>
+        </div>
+    
+    
+    
+      </>
     );
   };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 16186508055fd9253dc1e36ada9f448cce36d5ed  | 
|--------|--------|

### Summary:
Refactored `SizeDropdown` to be reusable and integrated it into `App.tsx` with dynamic settings.

**Key points**:
- **Refactored** `SizeDropdown` in `src/client/DropDown.tsx` to be reusable by accepting `settingKey` and `settingOptions` as props.
- **Updated** `src/client/App.tsx` to use the refactored `SizeDropdown` with `settingKey="boardSize"` and `settingOptions=["Small", "Medium", "Large"]`.
- **Removed** hardcoded dropdown options and replaced them with dynamic rendering based on `settingOptions`.
- **Improved** dropdown button text to be dynamically generated from `settingKey`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->